### PR TITLE
chromedriver latest version fix added

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,13 +29,14 @@ if [ -f $ENV_DIR/CHROMEDRIVER_VERSION ]; then
   VERSION=$(cat $ENV_DIR/CHROMEDRIVER_VERSION)
 else
   topic "Looking up latest chromedriver version"
-  LATEST="https://chromedriver.storage.googleapis.com/LATEST_RELEASE"
-  VERSION=`curl -s $LATEST`
+  LATEST="https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
+  VERSION=$(curl -s $LATEST | jq -r '.channels.Stable.version')
+
 fi
 indent "Version $VERSION"
 
 topic "Downloading chromedriver v$VERSION"
-ZIP_URL="https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip"
+ZIP_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$VERSION/linux64/chromedriver-linux64.zip"
 ZIP_LOCATION="/tmp/chromedriver.zip"
 curl -s -o $ZIP_LOCATION $ZIP_URL
 unzip -o $ZIP_LOCATION -d $BIN_DIR


### PR DESCRIPTION
After chromedriver version 114 old URL is not supporting, changed the[ new domain,]( https://googlechromelabs.github.io/chrome-for-testing/)